### PR TITLE
Updated ceph module to allow new ceph rgw naming format

### DIFF
--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -98,8 +98,8 @@ define ceph::rgw (
     warning( 'The syslog parameter is unused and deprecated. It will be removed in a future release.' )
   }
 
-  unless $name =~ /^radosgw\..+/ {
-    fail("Define name must be started with 'radosgw.'")
+  unless $name =~ /^radosgw|rgw\..+/ {
+    fail("Define name must be started with 'radosgw.' or 'rgw.'")
   }
 
   ceph_config {

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -98,7 +98,7 @@ define ceph::rgw (
     warning( 'The syslog parameter is unused and deprecated. It will be removed in a future release.' )
   }
 
-  unless $name =~ /^radosgw|rgw\..+/ {
+  unless $name =~ /^(radosgw|rgw)\..+/ {
     fail("Define name must be started with 'radosgw.' or 'rgw.'")
   }
 

--- a/manifests/rgw/civetweb.pp
+++ b/manifests/rgw/civetweb.pp
@@ -25,8 +25,8 @@ define ceph::rgw::civetweb (
   $rgw_frontends = 'civetweb port=7480',
 ) {
 
-  unless $name =~ /^radosgw\..+/ {
-    fail("Define name must be started with 'radosgw.'")
+  unless $name =~ /^radosgw|rgw\..+/ {
+    fail("Define name must be started with 'radosgw.' or 'rgw.'")
   }
 
   ceph_config {

--- a/manifests/rgw/civetweb.pp
+++ b/manifests/rgw/civetweb.pp
@@ -25,7 +25,7 @@ define ceph::rgw::civetweb (
   $rgw_frontends = 'civetweb port=7480',
 ) {
 
-  unless $name =~ /^radosgw|rgw\..+/ {
+  unless $name =~ /^(radosgw|rgw)\..+/ {
     fail("Define name must be started with 'radosgw.' or 'rgw.'")
   }
 

--- a/manifests/rgw/keystone.pp
+++ b/manifests/rgw/keystone.pp
@@ -105,7 +105,7 @@ define ceph::rgw::keystone (
   $user                             = undef,
 ) {
 
-  unless $name =~ /^radosgw|rgw\..+/ {
+  unless $name =~ /^(radosgw|rgw)\..+/ {
     fail("Define name must be started with 'radosgw.' or 'rgw.'")
   }
 

--- a/manifests/rgw/keystone.pp
+++ b/manifests/rgw/keystone.pp
@@ -105,8 +105,8 @@ define ceph::rgw::keystone (
   $user                             = undef,
 ) {
 
-  unless $name =~ /^radosgw\..+/ {
-    fail("Define name must be started with 'radosgw.'")
+  unless $name =~ /^radosgw|rgw\..+/ {
+    fail("Define name must be started with 'radosgw.' or 'rgw.'")
   }
 
   if $rgw_keystone_version {


### PR DESCRIPTION
new ceph naming format changed from radosgw to rgw.

This change addresses that to allow the module to accept the style as well as the old.