### PR TITLE
Pin yum packages to 14.2.11

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,7 +140,8 @@
 
 class ceph (
   $fsid,
-  $ensure                        = present,
+  # Override default ensure=installed until CCCP-3451 resolved
+  $ensure                        = '14.2.11',
   $authentication_type           = 'cephx',
   $keyring                       = undef,
   $osd_journal_size              = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,8 +140,7 @@
 
 class ceph (
   $fsid,
-  # Override default ensure=present until CCCP-3451 resolved
-  $ensure                        = '14.2.11',
+  $ensure                        = present,
   $authentication_type           = 'cephx',
   $keyring                       = undef,
   $osd_journal_size              = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,7 +140,7 @@
 
 class ceph (
   $fsid,
-  # Override default ensure=installed until CCCP-3451 resolved
+  # Override default ensure=present until CCCP-3451 resolved
   $ensure                        = '14.2.11',
   $authentication_type           = 'cephx',
   $keyring                       = undef,

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -139,7 +139,8 @@ define ceph::rgw (
   }
 
   package { $pkg_radosgw:
-    ensure => installed,
+    # Override default ensure=installed until CCCP-3451 resolved
+    ensure => '14.2.11',
     tag    => 'ceph',
   }
 

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -139,7 +139,9 @@ define ceph::rgw (
   }
 
   package { $pkg_radosgw:
-    # Override default ensure=installed until CCCP-3451 resolved
+    # Override default ensure=installed until https://tracker.ceph.com/issues/48382 resolved. CCCP-3451
+    # This pinning is specific to "ceph-radosgw" package. It works in tandem with a similar change
+    # in CCCP where we pin the "ceph" package.
     ensure => '14.2.11',
     tag    => 'ceph',
   }

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -139,6 +139,7 @@ define ceph::rgw (
   }
 
   package { $pkg_radosgw:
+    # HACK
     # Override default ensure=installed until https://tracker.ceph.com/issues/48382 resolved. CCCP-3451
     # There didn't seem to be a way to feed this as a parameter so we do the change inside the module.
     # This pinning is specific to "ceph-radosgw" package. It works in tandem with a similar change

--- a/manifests/rgw.pp
+++ b/manifests/rgw.pp
@@ -140,6 +140,7 @@ define ceph::rgw (
 
   package { $pkg_radosgw:
     # Override default ensure=installed until https://tracker.ceph.com/issues/48382 resolved. CCCP-3451
+    # There didn't seem to be a way to feed this as a parameter so we do the change inside the module.
     # This pinning is specific to "ceph-radosgw" package. It works in tandem with a similar change
     # in CCCP where we pin the "ceph" package.
     ensure => '14.2.11',


### PR DESCRIPTION
Set package installation invocation for:

- ceph-radosgw

to explicitly install 14.2.11 until such time when public Swift
buckets are known to work in a Nautilus 14.2.XX release.